### PR TITLE
Fix MonadWriter instance function 'pass'

### DIFF
--- a/Control/Monad/Trans/RSS/Lazy.hs
+++ b/Control/Monad/Trans/RSS/Lazy.hs
@@ -167,9 +167,9 @@ instance (Monoid w, Monad m) => MonadWriter w (RSST r w s m) where
     listen rw = RSST $ \r s -> do
         (a, (ns, nw)) <- runRSST' rw r s
         return ((a, nw), (ns, nw))
-    pass rw = RSST $ \r s -> do
-        ( (a, fw), (s', w) ) <- runRSST' rw r s
-        return (a, (s', fw w))
+    pass rw = RSST $ \r (s, w) -> do
+        ( (a, fw), (s', w') ) <- runRSST' rw r (s, mempty)
+        return (a, (s', w `mappend` fw w'))
 
 instance (Monoid w, Monad m) => MonadRWS r w s (RSST r w s m)
 

--- a/Control/Monad/Trans/RSS/Strict.hs
+++ b/Control/Monad/Trans/RSS/Strict.hs
@@ -136,7 +136,7 @@ instance (Functor m, MonadPlus m) => Alternative (RSST r w s m) where
     (<|>) = mplus
 
 instance (MonadFix m) => MonadFix (RSST r w s m) where
-    mfix f = RSST $ \r s -> mfix $ \ (a, _) -> runRSST' (f a) r s
+    mfix f = RSST $ \r s -> mfix $ \ ~(a, _) -> runRSST' (f a) r s
 
 instance MonadTrans (RSST r w s) where
     lift m = RSST $ \_ s -> do

--- a/Control/Monad/Trans/RSS/Strict.hs
+++ b/Control/Monad/Trans/RSS/Strict.hs
@@ -165,9 +165,9 @@ instance (Monoid w, Monad m) => MonadWriter w (RSST r w s m) where
     listen rw = RSST $ \r s -> do
         (a, (ns, nw)) <- runRSST' rw r s
         return ((a, nw), (ns, nw))
-    pass rw = RSST $ \r s -> do
-        ( (a, fw), (s', w) ) <- runRSST' rw r s
-        return (a, (s', fw w))
+    pass rw = RSST $ \r (s, w) -> do
+        ( (a, fw), (s', w') ) <- runRSST' rw r (s, mempty)
+        return (a, (s', w `mappend` fw w'))
 
 instance (Monoid w, Monad m) => MonadRWS r w s (RSST r w s m)
 

--- a/stateWriter.cabal
+++ b/stateWriter.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                stateWriter
-version:             0.2.4
+version:             0.2.5
 synopsis:            A faster variant of the RWS monad transformers.
 description:         This is a version of the RWS monad transformers that should be much faster than what's found in transformers. The writer in the strict version does not leak memory.
 license:             BSD3


### PR DESCRIPTION
Previously it applied the function from pass to all previous output - it should apply only to the writer passed in.

```
 *Control.Monad.Trans.RSS.Lazy Data.Maybe Data.Char> runRSS (do { tell "foo "; censor (map toUpper) $ tell "bar "; tell "baz" }) () ()

 ((),(),"foo BAR baz")  -- expected output
 ((),(),"FOO BAR baz")  -- previous output
```
